### PR TITLE
修复补全的边界问题

### DIFF
--- a/addons/godot_code_snippet/godot_code_snippet.gd
+++ b/addons/godot_code_snippet/godot_code_snippet.gd
@@ -62,6 +62,7 @@ func _on_code_completion_requested(code_edit : CodeEdit):
 		return
 	if default.is_empty(): return
 	for keyword in default:
+		if not keyword.contains(line_text.strip_edges()): continue
 		# 添加自定义补全项
 		code_edit.add_code_completion_option(
 			CodeEdit.KIND_FUNCTION,


### PR DESCRIPTION
<img width="275" height="176" alt="1695decb0151b8a60fb73605639f87d9" src="https://github.com/user-attachments/assets/eb8be3d7-3c8f-4d34-97b3-d84b6afe2c0d" />

通过判断keyword是否包含当前行来决定是否要补全